### PR TITLE
improved local storage test

### DIFF
--- a/angular-translate-storage-local.js
+++ b/angular-translate-storage-local.js
@@ -10,7 +10,17 @@ angular.module('pascalprecht.translate').factory('$translateLocalStorage', [
           $window.localStorage.setItem(name, value);
         }
       };
-    var $translateLocalStorage = 'localStorage' in $window && $window.localStorage !== null ? localStorageAdapter : $translateCookieStorage;
+    var hasLocalStorageSupport = 'localStorage' in $window && $window.localStorage !== null;
+    if (hasLocalStorageSupport) {
+      var testKey = 'pascalprecht.translate.storageTest';
+      try {
+        $window.localStorage.setItem(testKey, 'foo');
+        $window.localStorage.removeItem(testKey);
+      } catch (e){
+        hasLocalStorageSupport = false;
+      }
+    }
+    var $translateLocalStorage = hasLocalStorageSupport ? localStorageAdapter : $translateCookieStorage;
     return $translateLocalStorage;
   }
 ]);


### PR DESCRIPTION
Mobile Safari in private browsing mode will throw a QUOTAEXCEEDEDERROR on localStorage.setItem().
So this will test if set.Item is working for a testkey and otherwise fallback to CookieStorage which works fine in private browsing mode.
