### PR TITLE
Improved performance by limiting calls to localStorage.getItem().

### DIFF
--- a/angular-translate-storage-local.js
+++ b/angular-translate-storage-local.js
@@ -2,14 +2,23 @@ angular.module('pascalprecht.translate').factory('$translateLocalStorage', [
   '$window',
   '$translateCookieStorage',
   function ($window, $translateCookieStorage) {
-    var localStorageAdapter = {
+    var localStorageAdapter = (function() {
+      var langKey;
+      
+      return {
         get: function (name) {
-          return $window.localStorage.getItem(name);
+          if(!langKey) {
+            langKey = $window.localStorage.getItem(name);
+          }
+          
+          return langKey;
         },
         set: function (name, value) {
+          langKey=value;
           $window.localStorage.setItem(name, value);
         }
       };
+    }());
     var $translateLocalStorage = 'localStorage' in $window && $window.localStorage !== null ? localStorageAdapter : $translateCookieStorage;
     return $translateLocalStorage;
   }


### PR DESCRIPTION
The `get()` method is called many times, so save the language key in memory and serve it from there.

Here's a demo of how often `get()` is called even if there's very few strings:
http://plnkr.co/edit/nlytP5RPIeIzfJ6ZhoPU?p=info
(Look in JavaScript console.)
