### PR TITLE
Update version of angular-translate-storage-cookie

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,6 @@
   "main": "./angular-translate-storage-local.js",
   "dependencies": {
     "angular-translate": "~2.1.0",
-    "angular-translate-storage-cookie": "~2.0.0"
+    "angular-translate-storage-cookie": "~2.1.0"
   }
 }


### PR DESCRIPTION
I got "Unable to find a suitable version for angular-translate-storage-cookie, please choose one:" while I entered 2.1.0 for all angular-translate related dependencies because this bower.json still listed 2.0.0.
