### PR TITLE
Can now be installed via NPM and used with Browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Please file any issues and bugs in our main repository at [angular-translate/ang
 $ bower install angular-translate-storage-local
 ```
 
+### via NPM
+
+```bash
+$ npm install angular-translate-storage-local
+```
+
+
 ### via cdnjs
 
 Please have a look at https://cdnjs.com/libraries/angular-translate-storage-local for specific versions.

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   "bugs": {
     "url": "https://github.com/mchambaud/bower-angular-translate-storage-local/issues"
   },
-  "homepage": "https://github.com/mchambaud/bower-angular-translate-storage-local"
+  "homepage": "https://github.com/mchambaud/bower-angular-translate-storage-local",
+  "dependencies": {
+    "angular-translate": "^2.7.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "angular-translate-storage-local",
+  "version": "2.7.0",
+  "description": "Abstraction layer for localStorage. This service is used when telling angular-translate to use localStorage as storage.",
+  "main": "angular-translate-storage-local.js",
+  "repository": {
+    "type": "git",
+    "url": "https://mchambaud@github.com/mchambaud/bower-angular-translate-storage-local.git"
+  },
+  "keywords": [
+    "angular",
+    "angular-translate",
+    "angular-translate-storage-local"
+  ],
+  "author": "Pascal Precht",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mchambaud/bower-angular-translate-storage-local/issues"
+  },
+  "homepage": "https://github.com/mchambaud/bower-angular-translate-storage-local"
+}


### PR DESCRIPTION
Added PACKAGE.JSON to allow installing angular-translate-storage-local using NPM, enabling proper Browserification in the process.